### PR TITLE
feat(locale): Add locale support for instant parsing wihtout async

### DIFF
--- a/lib/src/jiffy.dart
+++ b/lib/src/jiffy.dart
@@ -17,9 +17,9 @@ class Jiffy {
 
   DateTime get dateTime => _dateTime;
 
-  Jiffy([var input, String? pattern]) {
+  Jiffy([var input, String? pattern, String? locale]) {
     _initializeDateTime(input, pattern);
-    _initializeLocale();
+    _initializeLocale(locale);
   }
 
   Jiffy.unixFromSecondsSinceEpoch(int timestamp) {
@@ -132,8 +132,8 @@ class Jiffy {
     }
   }
 
-  static void _initializeLocale() {
-    var currentLocale = Intl.getCurrentLocale();
+  static void _initializeLocale([String? locale]) {
+    var currentLocale = locale ?? Intl.getCurrentLocale();
     _defaultLocale = getLocale(currentLocale);
     _defaultLocale.code = currentLocale.toLowerCase();
   }

--- a/test/jiffy_relative_locale_test.dart
+++ b/test/jiffy_relative_locale_test.dart
@@ -10,6 +10,11 @@ void main() {
       expect(locales, isList);
     });
 
+    test('test should use locale parameter parse instantly', () {
+      var result = Jiffy('2019-09-01', null, 'tr');
+      expect(result.from('2019-10-01'), 'bir ay önce');
+    });
+
     test(
         'test show all available locales contains locales en, fr, de, zn_ch, ru, az',
         () {


### PR DESCRIPTION
**What does this PR do?**

I implemented simple locale support to instant parsing datetime without async. For example you can use Jiffy in model without async.  I added example model

 ```

class Article {
  final int? id;
  final String? title;
  final String? content;
  final String? timeAgo;

  factory Article.fromJson(Map<String, dynamic> json) {
    return Article(
        id: json['id'] ?? 0,
        title: json['title']['rendered'] ?? '',
        content: json['content']['rendered'] ?? '',
        timeAgo: Jiffy(json["date"], null, json["locale"]).fromNow()
  }
}
```

This PR are not breaking changes

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. Ex. `[x]` -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)