### PR TITLE
add support for "maxRelativeTimeUnit" for .fromNow() and .from()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Jiffy().yMMMMEEEEdjm; // Tuesday, March 2, 2021 3:20 PM
 ```dart
 Jiffy("2011-10-31", "yyyy-MM-dd").fromNow(); // 9 years ago
 
+Jiffy("2020-01-01", "yyyy-MM-dd").from(Jiffy("2021-12-31", "yyyy-MM-dd"), maxRelativeTimeUnit: Units.MONTH); // 24 months ago
+
 Jiffy().startOf(Units.DAY).fromNow(); // 19 hours ago
 
 Jiffy().endOf(Units.DAY).fromNow(); // in 5 hours

--- a/example/jiffy_example.dart
+++ b/example/jiffy_example.dart
@@ -16,13 +16,21 @@ Future<int> main() async {
   Jiffy([2019, 10, 19]).yMMMMd; // January 19, 2021
 
 // Using maps
-  Jiffy({'year': 2019, 'month': 10, 'day': 19, 'hour': 19})
-      .yMMMMEEEEdjm; // Monday, October 19, 2020 7:14 PM
+  Jiffy({'year': 2019, 'month': 10, 'day': 19, 'hour': 19}).yMMMMEEEEdjm; // Monday, October 19, 2020 7:14 PM
 
   // 'From Now' implementation
   Jiffy('2007-1-29').fromNow(); // 14 years ago
   Jiffy([2022, 10, 29]).fromNow(); // in a year
   Jiffy(DateTime(2050, 10, 29)).fromNow(); // in 30 years
+  
+  // 'From Now' with maxRelativeTimeUnit
+  Jiffy('2030-12-31').fromNow(maxRelativeTimeUnit: Units.MONTH); // 108 months
+  Jiffy('2021-12-31').fromNow(maxRelativeTimeUnit: Units.MINUTE); // 59794 minutes ago
+  Jiffy('2021-12-31').fromNow(maxRelativeTimeUnit: Units.HOUR); // 997 hours ago
+  Jiffy('2021-12-31').fromNow(maxRelativeTimeUnit: Units.DAY); // 42 days ago
+  Jiffy('2020-12-31').fromNow(maxRelativeTimeUnit: Units.MONTH); // 14 months ago
+  Jiffy('2000-12-31').fromNow(maxRelativeTimeUnit: Units.MONTH); // 257 months ago
+  Jiffy('2000-12-31').fromNow(maxRelativeTimeUnit: Units.YEAR); // 21 years ago
 
   Jiffy().startOf(Units.HOUR).fromNow(); // 9 minutes ago
 
@@ -33,6 +41,7 @@ Future<int> main() async {
   jiffy2.from(jiffy3); // a day ago
 
   jiffy2.from([2017, 1, 30]); // 2 days ago
+  jiffy2.from([2017, 1, 30], maxRelativeTimeUnit: Units.MONTH); // 122 months ago
 
 //  Displaying the 'Difference' between two date times
 //  By default, 'diff' method, get the difference in milliseconds

--- a/lib/src/jiffy.dart
+++ b/lib/src/jiffy.dart
@@ -467,13 +467,13 @@ class Jiffy {
 
   String get jms => DateFormat.jms().format(_dateTime);
 
-  String fromNow() {
-    return _defaultLocale.getRelativeTime(_dateTime);
+  String fromNow({Units? maxRelativeTimeUnit}) {
+    return _defaultLocale.getRelativeTime(_dateTime, maxRelativeTimeUnit: maxRelativeTimeUnit);
   }
 
-  String from(var input) {
+  String from(var input, {Units? maxRelativeTimeUnit}) {
     var dateTime = _parse(input);
-    return _defaultLocale.getRelativeTime(_dateTime, dateTime);
+    return _defaultLocale.getRelativeTime(_dateTime, date2: dateTime, maxRelativeTimeUnit: maxRelativeTimeUnit);
   }
 
   num diff(var input, [Units units = Units.MILLISECOND, bool asFloat = false]) {

--- a/lib/src/locale/locale.dart
+++ b/lib/src/locale/locale.dart
@@ -1,5 +1,6 @@
 import 'package:jiffy/src/enums/startOfWeek.dart';
 import 'package:jiffy/src/locale/relativeTime.dart';
+import 'package:jiffy/src/enums/units.dart';
 
 abstract class Locale {
   late String code;
@@ -11,7 +12,11 @@ abstract class Locale {
 
   StartOfWeek startOfWeek();
 
-  String getRelativeTime(DateTime date1, [DateTime? date2]) {
+  String getRelativeTime(
+    DateTime date1, {
+    DateTime? date2,
+    Units? maxRelativeTimeUnit = Units.YEAR, // ONLY SUPPORT MINUTE, HOUR, DAY, MONTH, YEAR
+  }) {
     final relative = relativeTime();
     final _date2 = date2 ?? DateTime.now();
     final _allowFromNow = _date2.isBefore(date1);
@@ -40,19 +45,19 @@ abstract class Locale {
       result = relative.lessThanOneMinute(seconds.round());
     } else if (seconds < 90) {
       result = relative.aboutAMinute(minutes.round());
-    } else if (minutes < 45) {
+    } else if (minutes < 45 || (minutes >= 45 && maxRelativeTimeUnit == Units.MINUTE)) {
       result = relative.minutes(minutes.round());
     } else if (minutes < 90) {
       result = relative.aboutAnHour(minutes.round());
-    } else if (hours < 24) {
+    } else if (hours < 24 || (hours >= 24 && maxRelativeTimeUnit == Units.HOUR)) {
       result = relative.hours(hours.round());
     } else if (hours < 48) {
       result = relative.aDay(hours.round());
-    } else if (days < 30) {
+    } else if (days < 30 || (days >= 30 && maxRelativeTimeUnit == Units.DAY)) {
       result = relative.days(days.round());
     } else if (days < 60) {
       result = relative.aboutAMonth(days.round());
-    } else if (days < 365) {
+    } else if (days < 365 || (days >= 365 && maxRelativeTimeUnit == Units.MONTH)) {
       result = relative.months(months.round());
     } else if (years < 2) {
       result = relative.aboutAYear(months.round());

--- a/test/jiffy_display_test.dart
+++ b/test/jiffy_display_test.dart
@@ -77,6 +77,14 @@ void main() {
       expect(jiffy2.fromNow(), 'a year ago');
     });
     test(
+        'test Jiffy().fromNow() with maxRelativeTimeUnit method with parsing date time should return correct relative date time string',
+        () {
+      var jiffy1 = Jiffy()..add(duration: Duration(hours: 20));
+      expect(jiffy1.fromNow(maxRelativeTimeUnit: Units.MINUTE), 'in 1200 minutes');
+      var jiffy2 = Jiffy()..subtract(months: 20);
+      expect(jiffy2.fromNow(maxRelativeTimeUnit: Units.MONTH), '20 months ago');
+    });
+    test(
         'test Jiffy().from() method with parsing date time should return correct relative date time string',
         () {
       var jiffy1 = Jiffy([2019, 10, 16]);
@@ -85,6 +93,16 @@ void main() {
       expect(Jiffy('2019, 10, 20', 'yyyy, MM, dd').from(jiffy2), '6 days ago');
       var jiffy3 = Jiffy([2019, 10, 16])..subtract(months: 20);
       expect(Jiffy('2019, 10, 20', 'yyyy, MM, dd').from(jiffy3), 'in a year');
+    });
+    test(
+        'test Jiffy().from() with maxRelativeTimeUnit method with parsing date time should return correct relative date time string',
+        () {
+      var jiffy1 = Jiffy([2019, 10, 16]);
+      expect(Jiffy('2019, 10, 20', 'yyyy, MM, dd').from(jiffy1, maxRelativeTimeUnit: Units.HOUR), 'in 96 hours');
+      var jiffy2 = Jiffy([2019, 10, 16])..add(months: 10);
+      expect(Jiffy('2019, 10, 20', 'yyyy, MM, dd').from(jiffy2, maxRelativeTimeUnit: Units.DAY), '301 days ago');
+      var jiffy3 = Jiffy('2021-12-31', 'yyyy-MM-dd');
+      expect(Jiffy('2020-01-01', 'yyyy-MM-dd').from(jiffy3, maxRelativeTimeUnit: Units.MONTH), '24 months ago');
     });
   });
 


### PR DESCRIPTION
**What does this PR do?**
Add new optional parameters ("**maxRelativeTimeUnit**") for methods - **Jiffy().fromNow()** and **Jiffy().from()**. 

This parameters allow the relative time to be shown at defined maxRelativeTimeUnit (minute, hour, day, month).

For example, 

1. "[in] 365 days [ago]", instead of "[in] 1 year [ago]"
2. "[in] 60 days [ago]", instead of "[in] 2 months [ago]"
3. "[in] 48 hours [ago]", instead of "[in] 2 days [ago]"

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. Ex. `[x]` -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. Ex. `[x]` -->
- [x] Directed the PR to `develop` branch and not the `master` branch
- [x] Wrote additional tests, if needed
- [x] All tests have passed
- [x] I have updated the documentation accordingly, if needed.