### PR TITLE
update locale( ) methods in jiffy.dart

### DIFF
--- a/lib/src/jiffy.dart
+++ b/lib/src/jiffy.dart
@@ -138,13 +138,16 @@ class Jiffy {
     _defaultLocale.code = currentLocale.toLowerCase();
   }
 
-  static Future<Locale> locale([String? locale]) async {
+  static Future<Locale> locale([String? locale, bool? enDigits]) async {
     _initializeLocale();
     if (locale != null) {
       if (isLocalAvailable(locale)) {
         throw JiffyException(
                 'The locale "$locale" does not exist in Jiffy, run Jiffy.getAllAvailableLocales() for more locales')
             .cause;
+      }
+      if(enDigits != null){
+        DateFormat.useNativeDigitsByDefaultFor(locale, enDigits);
       }
       await initializeDateFormatting();
       Intl.defaultLocale = locale;


### PR DESCRIPTION
by default when changing the locale to "ar" the jiffy package will 
use the Arabic numbers 	١,٢,٣ in the dates like this: 

 السبت، ١٩ أكتوبر ٢٠١٩ ٧:٢٧ م

so, in this collaboration I tried to add an option (this option called "enDigits") to use the English numbers (ASCII Digits) with whatever the locale is so, if we add this option when changing the locale to "ar" for example the result will be like this: 

 السبت، 19 أكتوبر 2019 7:27 م
