### PR TITLE
Added RelativeDateTime class overrides related to Locale

### DIFF
--- a/example/jiffy_custom_locales_example.dart
+++ b/example/jiffy_custom_locales_example.dart
@@ -1,0 +1,73 @@
+import 'package:jiffy/jiffy.dart';
+import 'package:jiffy/src/locale/locale.dart';
+import 'package:jiffy/src/locale/relative_date_time.dart';
+
+void main() {
+  //  EnsureInitialized
+  Jiffy.ensureInitialized(locales: {
+    'en': CustomEnLocale(),
+    'en_us': CustomEnUsLocale(),
+  });
+
+  // Relative date time
+  // From X
+  Jiffy.parse('1997/09/23').from(Jiffy.parse('2002/10/26')); // 5 years Ago
+  // From Now
+  Jiffy.parse('1997/09/23').fromNow(); // 25 years Ago
+}
+
+/// Create CustomEnLocale Class
+class CustomEnLocale extends Locale {
+  @override
+  String code() => 'en';
+
+  @override
+  List<String> ordinals() =>
+      List.from(['st', 'nd', 'rd', 'th'], growable: false);
+
+  @override
+  StartOfWeek startOfWeek() => StartOfWeek.sunday;
+
+  @override
+  RelativeDateTime relativeDateTime() => EnRelativeTime();
+}
+
+class CustomEnUsLocale extends CustomEnLocale {
+  @override
+  String code() => 'en_us';
+}
+
+class EnRelativeTime extends RelativeDateTime {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => 'In';
+  @override
+  String suffixAgo() => 'Ago';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds) => 'a Few Seconds';
+  @override
+  String aboutAMinute(int minutes) => 'a Minute';
+  @override
+  String minutes(int minutes) => '$minutes Minutes';
+  @override
+  String aboutAnHour(int minutes) => 'an Hour';
+  @override
+  String hours(int hours) => '$hours Hours';
+  @override
+  String aDay(int hours) => 'a Day';
+  @override
+  String days(int days) => '$days Days';
+  @override
+  String aboutAMonth(int days) => 'a Month';
+  @override
+  String months(int months) => '$months Months';
+  @override
+  String aboutAYear(int year) => 'a Year';
+  @override
+  String years(int years) => '$years Years';
+  @override
+  String wordSeparator() => ' ';
+}

--- a/lib/src/jiffy.dart
+++ b/lib/src/jiffy.dart
@@ -1,5 +1,5 @@
-import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 
 import './default_display.dart';
 import './display.dart';
@@ -32,6 +32,16 @@ class Jiffy {
     _initializeDependencies();
     _initializeLocale();
     _initializeDateTime(input, pattern, isUtc);
+  }
+
+  /// ensureInitialized must be called before using [Jiffy].
+  ///
+  /// If [locales] is not null, you can update [locales].
+  ///
+  static Future<void> ensureInitialized({Map<String, Locale>? locales}) async {
+    if (locales != null) {
+      supported_locales.updateSupportedLocales(locales);
+    }
   }
 
   /// Constructs a new [Jiffy] instance by parsing a [String].

--- a/lib/src/locale/supported_locales.dart
+++ b/lib/src/locale/supported_locales.dart
@@ -1,5 +1,7 @@
 import 'locale.dart';
 import 'locales/ar_locale.dart';
+import 'locales/az_locale.dart';
+import 'locales/bn_locale.dart';
 import 'locales/cs_locale.dart';
 import 'locales/de_locale.dart';
 import 'locales/en_locale.dart';
@@ -18,13 +20,11 @@ import 'locales/pl_locale.dart';
 import 'locales/pt_locale.dart';
 import 'locales/ru_locale.dart';
 import 'locales/sk_locale.dart';
-import 'locales/th_locale.dart';
-import 'locales/uk_locale.dart';
-import 'locales/az_locale.dart';
 import 'locales/sv_locale.dart';
+import 'locales/th_locale.dart';
 import 'locales/tr_locale.dart';
+import 'locales/uk_locale.dart';
 import 'locales/zh_locale.dart';
-import 'locales/bn_locale.dart';
 
 Map<String, Locale> _supportedLocales = {
   'en': EnLocale(),
@@ -92,4 +92,17 @@ bool isLocalSupported(String locale) {
 
 List<String> getSupportedLocales() {
   return _supportedLocales.keys.toList();
+}
+
+void updateSupportedLocales(Map<String, Locale> locales) {
+  Map<String, Locale> updateSupportedLocales = Map.from(_supportedLocales);
+  for (var key in locales.keys) {
+    if (isLocalSupported(key)) {
+      final locale = locales[key];
+      if (locale != null) {
+        updateSupportedLocales[key] = locale;
+      }
+    }
+  }
+  _supportedLocales = updateSupportedLocales;
 }


### PR DESCRIPTION
**What does this PR do?**

Purpose of overriding RelativeDateTime Class and modifying text.

**Issue Reference**

None

**Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Maintenance change (non-breaking change such as upgrading a dependency, refactoring, or making a lint fix)
- [ ] Documentation update
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)

**Screenshots**

None

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. Ex. `[x]` -->

- [x] Wrote additional tests, if needed
- [x] All tests have passed, you can find the scripts from the `./bin` folder
- [ ] I have updated the documentation accordingly, if needed.

**Additional Information**

An appropriate section could not be found to override and use the RelativeDateTime Class of the defined Support Locale Class. So we created the ensureInitialized function. If there is a better way, I hope it improves.