### PR TITLE
Improved hindi translation for 'ago'

### DIFF
--- a/lib/src/locale/locales/hi_locale.dart
+++ b/lib/src/locale/locales/hi_locale.dart
@@ -22,7 +22,7 @@ class HiRelativeTime extends RelativeDateTime {
   @override
   String prefixFromNow() => '';
   @override
-  String suffixAgo() => 'पहले';
+  String suffixAgo() => 'पूर्व';
   @override
   String suffixFromNow() => 'में';
   @override


### PR DESCRIPTION

**What does this PR do?**

This PR fixes the Hindi translation for 'ago'
पूर्व is a better hindi translation for 'ago'.
The current word पहले means 'before' and not 'ago'.


**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. Ex. `[x]` -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance change (non-breaking change such as upgrading a dependency, refactoring, or making a lint fix)
- [ ] Documentation update
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)


**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. Ex. `[x]` -->

- [x] Wrote additional tests, if needed
- [x] All tests have passed, you can find the scripts from the `./bin` folder
- [x] I have updated the documentation accordingly, if needed.

**Additional Information**

Reference to Hindi dictionary, that explains why this is a better translation:
https://www.collinsdictionary.com/hi/dictionary/hindi-english/%E0%A4%AA%E0%A5%82%E0%A4%B0%E0%A5%8D%E0%A4%B5

Also, I am a native and profecient Hindi speaker.