### PR TITLE
JIFFY[257] - Fix: Use NumberFormat for locale-aware numeral parsing

### DIFF
--- a/lib/src/getter.dart
+++ b/lib/src/getter.dart
@@ -59,11 +59,11 @@ class Getter {
   int month(DateTime dateTime) => dateTime.month;
 
   int quarterOfYear(DateTime dateTime, Locale locale) {
-    return int.parse(DateFormat('Q', locale.code).format(dateTime));
+    return _toInt(DateFormat('Q', locale.code).format(dateTime), locale);
   }
 
   int dayOfYear(DateTime dateTime, Locale locale) {
-    return int.parse(DateFormat('D', locale.code).format(dateTime));
+    return _toInt(DateFormat('D', locale.code).format(dateTime), locale);
   }
 
   int year(DateTime dateTime) => dateTime.year;
@@ -72,6 +72,10 @@ class Getter {
     var result = daysInMonthArray[month];
     if (month == 2 && Query.isLeapYear(year)) result++;
     return result;
+  }
+
+  int _toInt(String localeNumber, Locale locale) {
+    return NumberFormat.decimalPattern(locale.code).parse(localeNumber).toInt();
   }
 
   static final List<int> daysInMonthArray = List.from(

--- a/test/src/getter_test.dart
+++ b/test/src/getter_test.dart
@@ -165,6 +165,20 @@ void main() {
       });
     }
 
+    test('Should successfully get day of year for non-standard number symbols',
+        () async {
+      // Setup
+      await Jiffy.setLocale('bn');
+      final newLocale = Jiffy.now().locale;
+
+      // Execute
+      final actualDayOfYear =
+          underTest.dayOfYear(DateTime(1997, 9, 23), newLocale);
+
+      // Verify
+      expect(actualDayOfYear, 266);
+    });
+
     for (var testData in weekOfYearTestData()) {
       test('Should successfully get week of year', () {
         // Setup
@@ -190,6 +204,20 @@ void main() {
         expect(actualQuarterOfYear, testData['expectedQuarterOfYear']);
       });
     }
+
+    test('Should successfully get quarter for non-standard number symbols',
+        () async {
+      // Setup
+      await Jiffy.setLocale('bn');
+      final newLocale = Jiffy.now().locale;
+
+      // Execute
+      final actualDayOfYear =
+          underTest.quarterOfYear(DateTime(2022, 4, 1), newLocale);
+
+      // Verify
+      expect(actualDayOfYear, 2);
+    });
   });
 
   for (var testData in daysInMonthTestData()) {


### PR DESCRIPTION
**What does this PR do?**

Jiffy was failing to parse numbers in locales that use non-standard numerals (e.g., Bengali, Arabic, etc.). For example, when retrieving the day of the year, it might return ৭৮ (Bengali for 78), but Jiffy would attempt to parse it as an integer and fail.

### Solution
Used [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) from the Intl package to correctly convert locale-specific numerals to standard numerals.

This ensures that Jiffy can properly handle numbers from different locales without parsing errors.

**Issue Reference**

<!-- If applicable, list any related GitHub issues that this PR addresses or fixes. E.g. Fixes #123 -->

Fixes #257

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. Ex. `[x]` -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance change (non-breaking change such as upgrading a dependency, refactoring, or making a lint fix)
- [ ] Documentation update
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)

**Screenshots**

If applicable, add screenshots to help explain your problem.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. Ex. `[x]` -->

- [x] Wrote additional tests, if needed
- [x] All tests have passed, you can find the scripts from the `./bin` folder
- [ ] I have updated the documentation accordingly, if needed.

**Additional Information**

<!-- Add any additional information that you think may be relevant to the review of your PR, such as performance considerations, design decisions, or trade-offs that were made. -->